### PR TITLE
Fix a nick changing issue

### DIFF
--- a/DideRobot.py
+++ b/DideRobot.py
@@ -113,6 +113,7 @@ class DideRobot(irc.IRCClient):
 				userlist.append(newaddress)
 				userlist.remove(prefix)
 				self.factory.logger.log("{} changed their nick from {} to {}".format(prefix, oldnick, newnick), channel)
+		irc.IRCClient.irc_NICK(self, prefix, params)
 
 	#Misc. logging
 	#def topicUpdated(self, user, channel, newTopic):


### PR DESCRIPTION
TM brought to my attention that irc_NICK already has an implementation in IRCClient. By overriding it and not calling the superclass function, nickChanged is never called, meaning that the bot won't internally update its own nickname.
