### PR TITLE
Remove card referencing Rwandan Genocide.

### DIFF
--- a/data/generators/CardsAgainstHumanityWhiteCards.txt
+++ b/data/generators/CardsAgainstHumanityWhiteCards.txt
@@ -416,7 +416,6 @@ Used panties
 A tribe of warrior women
 The penny whistle solo from "My Heart Will Go On"
 An oversized lollipop
-Helplessly giggling at the mention of Hutus and Tutsis
 Not wearing pants
 Consensual sex
 Her Majesty, Queen Elizabeth II


### PR DESCRIPTION
Removing card "Helplessly giggling at the mention of Hutus and Tutsis" for references to genocide.